### PR TITLE
Search

### DIFF
--- a/base/apps.py
+++ b/base/apps.py
@@ -1,6 +1,13 @@
 from django.apps import AppConfig
+from watson import search
 
 
 class BaseConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'base'
+
+    def ready(self):
+        all_models = self.get_models()
+        
+        for model in all_models:
+            search.register(model)

--- a/base/models.py
+++ b/base/models.py
@@ -27,6 +27,10 @@ class Book(models.Model):
     def __str__(self):
         return self.title
 
+    def get_searchable_text(self):
+        # Explicitly convert numeric fields to strings
+        return f"{self.isbn} {self.title} {self.author} {self.genre} {self.price} {self.publication_date} {self.description} {self.stock_quantity}"
+
     class Meta:
         ordering = ['pk']
         verbose_name = 'Книга'
@@ -47,6 +51,12 @@ class Author(models.Model):
     def __str__(self):
         return f"{self.first_name} {self.last_name}"
 
+    def get_searchable_text(self):
+        """
+        Combines first name, last name, and bio for full-text search.
+        """
+        return f"{self.first_name} {self.last_name} {self.bio}"
+    
     class Meta:
         ordering = ['pk']
         verbose_name = 'Автор'
@@ -63,6 +73,13 @@ class Genre(models.Model):
         super(Genre, self).save(*args, **kwargs)
 
     def __str__(self):
+        return self.name
+    
+
+    def get_searchable_text(self):
+        """
+        Returns the genre name for full-text search.
+        """
         return self.name
 
     class Meta:
@@ -86,6 +103,12 @@ class OrderItem(models.Model):
 
         super(OrderItem, self).save(*args, **kwargs)
 
+    def get_searchable_text(self):
+        """
+        Combines book title, ISBN, quantity, and price for full-text search.
+        """
+        return f"{self.book.title} {self.book.isbn} {self.quantity} {self.price}"
+
     class Meta:
         ordering = ['pk']
         verbose_name = 'Замовлений товар'
@@ -99,6 +122,12 @@ class Bill(models.Model):
     def __str__(self):
         return f"Bill {self.pk} - {self.date}"
 
+    def get_searchable_text(self):
+        """
+        Combines the bill date and total amount for full-text search.
+        """
+        return f"{self.date} {self.total_amount}"
+    
     class Meta:
         ordering = ['pk']
         verbose_name = 'Рахунок'

--- a/base/templates/base/include/form.html
+++ b/base/templates/base/include/form.html
@@ -4,7 +4,7 @@
 
 <h2>{{ model_name|title }}</h2>
 
-<input type="text" placeholder="Пошук книг за назвою, автором або жанром..." id="search-books">
+{% include 'base/include/search_bar.html' %}
 
 <div class="form-container" id="form-container" style="display: {% if form.errors %} block {% else %} none {% endif %};">
     <h3>{{ add_button_name }}</h3>

--- a/base/templates/base/include/search_bar.html
+++ b/base/templates/base/include/search_bar.html
@@ -1,0 +1,4 @@
+<form action="{% url 'search' %}" method="get">
+    <input type="text" name="query" placeholder="Пошук..." value="{{ request.GET.query }}">
+    <button type="submit"><i class="fas fa-search"></i></button>
+</form>

--- a/base/templates/base/search_results.html
+++ b/base/templates/base/search_results.html
@@ -1,0 +1,27 @@
+{% extends 'base/base.html' %}
+
+{% block content %}
+
+{% include 'base/include/search_bar.html' %}
+
+    <h2>Результати пошуку для: "{{ query }}"</h2>
+    <div>
+        {% if results %}
+            <ul>
+                {% for result in results %}
+                    <li>
+                        <h3>{{ result.model_name }}</h3>
+                        <ul>
+                            {% for field, value in result.fields.items %}
+                                <li><strong>{{ field }}:</strong> {{ value }}</li>
+                            {% endfor %}
+                        </ul>
+                    </li>
+                    <hr>
+                {% endfor %}
+            </ul>
+        {% else %}
+            <p>Не знайдено результатів для "{{ query }}".</p>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/base/urls.py
+++ b/base/urls.py
@@ -6,6 +6,8 @@ from . import utils
 urlpatterns = [
     # Home URL
     path('', RedirectView.as_view(url='books/', permanent=True)),
+    path('search/', SearchView.as_view(), name='search'),
+
 
     # Book URLs
     path('books/', BookView.as_view(), name='book_list'),

--- a/base/views.py
+++ b/base/views.py
@@ -125,15 +125,12 @@ class SearchView(View):
             # Perform search across all registered models
             search_results = watson_search.search(query)
 
-            # Build results with relevant fields dynamically
             for result in search_results:
-                # Get model's fields
                 fields = {
-                    field.verbose_name: getattr(result.object, field.name, '')  # Use `field.name` to access attribute
+                    field.verbose_name: getattr(result.object, field.name, '')
                     for field in result.object._meta.fields
                 }
                 
-                # Add the model's human-readable name and the field values
                 results.append({
                     'model_name': result.object._meta.verbose_name,  # Model name
                     'fields': fields,  # Fields and values for each object

--- a/readery/settings.py
+++ b/readery/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'watson',
     'debug_toolbar',
     'base.apps.BaseConfig',
 ]
@@ -53,6 +54,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'watson.middleware.SearchContextMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ asgiref==3.8.1
 Django==5.1.2
 django-debug-toolbar==4.4.6
 django-redis==5.4.0
+django-watson==1.6.3
+mysqlclient==2.2.5
 psycopg2==2.9.10
 python-dotenv==1.0.1
 redis==5.2.0


### PR DESCRIPTION
Added Watson Search with Support for Numeric Fields

Added search functionality using Watson across all models in the base app. It ensures that both text and numeric fields are searchable by converting them to strings. I’ve also set up automatic registration for models and updated the search view to display results from all models. A rebuild of the Watson index is required for the changes to take effect.